### PR TITLE
Fix auth error when user has multiple accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__/
 .env
+venv/
 tmp/
 
 # Distribution / packaging
@@ -21,3 +22,6 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -52,8 +52,29 @@ async def main():
 asyncio.run(main())
 ```
 
+BCHydro offers [view-only accounts](https://app.bchydro.com/BCHCustomerPortal/web/accountAccessView.html),
+as a more secure option.
 
 ## Todo
 
 - [ ] Tests
 - [ ] Publish on release, not tag
+- [ ] Handle account locking?
+    ```html
+    <div id="alertMessage" class="alert error"><h3 class="icon">Sorry, your account is locked</h3></div>
+    <div>
+        <p>To ensure your account security, we've locked your account to prevent further attempts to log in.</p>
+        <p>You may try again after 5 minutes, or contact Customer Service.</p>
+        <p>
+            <a name="resetPassword" class="primary button" href="/BCHCustomerPortal/forgotPassword.html">Reset password</a>
+            <a name="returnToLogin" class="secondary button" href="/BCHCustomerPortal/web/login.html">Return to login</a>
+        </p>
+    </div>
+    </div>
+
+    </div>
+    ```
+
+## Disclaimer
+
+This package has been developed without the express permission of BC Hydro. It accesses data by submitting forms that end-users would typically use in a browser. I'd love to work with BC Hydro to find a better way to access this data, perhaps through an official API... if you know anyone that works there, pass this along!

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ async def main():
     a = BCHydroApi()
     await a.authenticate("username", "password")
 
-    usage = await a.get_daily_usage()
+    usage = await a.get_usage(hourly=False)
     print(usage.electricity)
     print(a.get_latest_point())
     print(a.get_latest_usage())

--- a/bchydro/api.py
+++ b/bchydro/api.py
@@ -102,6 +102,9 @@ class BCHydroApi:
         return True
 
     async def get_daily_usage(self) -> BCHydroDailyUsage:
+        return await self.get_usage(hourly=False)
+
+    async def get_usage(self, hourly = False) -> BCHydroDailyUsage:
         async with aiohttp.ClientSession(
             cookie_jar=self._cookie_jar, headers={"User-Agent": USER_AGENT}
         ) as session:
@@ -111,7 +114,7 @@ class BCHydroApi:
                     "Slid": self.account.evpSlid,
                     "Account": self.account.evpAccount,
                     "ChartType": "column",
-                    "Granularity": "daily",
+                    "Granularity": hourly and "hourly" or "daily",
                     "Overlays": "none",
                     "DateRange": "currentBill",
                     "StartDateTime": self.account.evpBillingStart,

--- a/bchydro/api.py
+++ b/bchydro/api.py
@@ -24,26 +24,30 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class BCHydroApi:
-    def __init__(self):
+    def __init__(self, username, password):
         """Initialize the sensor."""
+        self._username = username
+        self._password = password
         self._cookie_jar = None
         self._bchydroparam = None
         self.account: BCHydroAccount = None
         self.usage: BCHydroDailyUsage = None
         self.rates: BCHydroRates = None
 
-    async def authenticate(self, username, password) -> bool:
+    async def authenticate(self) -> bool:
         async with aiohttp.ClientSession(headers={"User-Agent": USER_AGENT}) as session:
             response = await session.post(
                 URL_POST_LOGIN,
                 data={
                     "realm": "bch-ps",
-                    "email": username,
-                    "password": password,
+                    "email": self._username,
+                    "password": self._password,
                     "gotoUrl": "https://app.bchydro.com:443/BCHCustomerPortal/web/login.html",
                 },
             )
             response.raise_for_status()
+            _LOGGER.debug('history:', response.history)
+
             if response.status != 200:
                 return False
 
@@ -73,6 +77,10 @@ class BCHydroApi:
                     "Login failed - unable to find bchydroparam. Are your credentials set?"
                 )
                 raise
+
+            alert_errors = soup.find(True, {'class': ['alert', 'error']})
+            if alert_errors:
+                raise Exception("Detected login page error(s): " + alert_errors.text)
 
             try:
                 response = await session.get(URL_GET_ACCOUNT_JSON)
@@ -105,6 +113,10 @@ class BCHydroApi:
         return await self.get_usage(hourly=False)
 
     async def get_usage(self, hourly = False) -> BCHydroDailyUsage:
+        if not self.account:
+            _LOGGER.error("Unauthenticated")
+            raise Exception("Unauthenticated")
+
         async with aiohttp.ClientSession(
             cookie_jar=self._cookie_jar, headers={"User-Agent": USER_AGENT}
         ) as session:
@@ -165,6 +177,7 @@ class BCHydroApi:
 
             except ET.ParseError as e:
                 _LOGGER.error("Unable to parse XML from string: %s -- %s", e, text)
+                raise
             except Exception as e:
                 _LOGGER.error("Unexpected error: %s", e)
                 raise
@@ -175,17 +188,33 @@ class BCHydroApi:
         return point.quality == "ACTUAL"
 
     def get_latest_point(self) -> BCHydroDailyElectricity:
+        if not self.account:
+            _LOGGER.error("Unauthenticated")
+            return
+
         valid = list(filter(self.is_valid, self.usage.electricity))
         return valid[-1] if len(valid) else None
 
     def get_latest_interval(self) -> BCHydroInterval:
+        if not self.account:
+            _LOGGER.error("Unauthenticated")
+            return
+
         valid = list(filter(self.is_valid, self.usage.electricity))
         return valid[-1].interval if len(valid) else None
 
     def get_latest_usage(self):
+        if not self.account:
+            _LOGGER.error("Unauthenticated")
+            return
+
         valid = list(filter(self.is_valid, self.usage.electricity))
         return valid[-1].consumption if len(valid) else None
 
     def get_latest_cost(self):
+        if not self.account:
+            _LOGGER.error("Unauthenticated")
+            return
+
         valid = list(filter(self.is_valid, self.usage.electricity))
         return valid[-1].cost if len(valid) else None

--- a/bchydro/const.py
+++ b/bchydro/const.py
@@ -6,6 +6,9 @@ USER_AGENT = "https://github.com/emcniece/hass-bchydro#disclaimer"
 # Main login page. Several redirects follow.
 URL_POST_LOGIN = "https://app.bchydro.com/sso/UI/Login"
 
+URL_GET_ACCOUNTS = "https://app.bchydro.com/BCHCustomerPortal/web/getAccounts.html"
+URL_ACCOUNTS_OVERVIEW = "https://app.bchydro.com/BCHCustomerPortal/web/accountsOverview.html"
+
 # This GET endpoint returns JSON account details.
 URL_GET_ACCOUNT_JSON = "https://app.bchydro.com/evportlet/web/global-data.html"
 

--- a/bchydro/const.py
+++ b/bchydro/const.py
@@ -1,7 +1,7 @@
 """BCHydro Constants"""
 
 # Customized user agent for getting the attention of BCHydro devs
-USER_AGENT = "https://github.com/emcniece/hass-bchydro#disclaimer"
+USER_AGENT = "https://github.com/emcniece/bchydro#disclaimer"
 
 # Main login page. Several redirects follow.
 URL_POST_LOGIN = "https://app.bchydro.com/sso/UI/Login"

--- a/bchydro/types.py
+++ b/bchydro/types.py
@@ -23,6 +23,8 @@ class BCHydroInterval:
         self.start = start
         self.end = end
 
+    def __repr__(self):
+        return f"BCHydroInterval('{self.start}', '{self.end}')"
 
 class BCHydroDailyElectricity:
     def __init__(
@@ -38,6 +40,9 @@ class BCHydroDailyElectricity:
         self.consumption = consumption
         self.interval = interval
         self.cost = cost
+
+    def __repr__(self):
+        return f"BCHydroDailyElectricity('{self.type}', '{self.quality}', {self.consumption}, {self.interval}, {self.cost})"
 
 
 # Account details returned from the account JSON response.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 beautifulsoup4
-p2
-p3
+aiohttp

--- a/test.py
+++ b/test.py
@@ -9,8 +9,9 @@ a = BCHydroApi()
 async def main():
     await a.authenticate(os.environ.get("BCH_USER"), os.environ.get("BCH_PASS"))
 
-    usage = await a.get_daily_usage()
-    print(usage.electricity)
+    usage = await a.get_usage(hourly=False)
+    for data in usage.electricity:
+        print (data.interval.start, data.interval.end, data.cost, data.consumption)
 
     print(a.get_latest_point())
     print(a.get_latest_interval().start, a.get_latest_interval().end)

--- a/test.py
+++ b/test.py
@@ -3,16 +3,12 @@ import asyncio
 
 from bchydro import BCHydroApi
 
-a = BCHydroApi()
-
-
 async def main():
-    await a.authenticate(os.environ.get("BCH_USER"), os.environ.get("BCH_PASS"))
-
+    a = BCHydroApi(os.environ.get("BCH_USER"), os.environ.get("BCH_PASS"))
+    await a.authenticate()
     usage = await a.get_usage(hourly=False)
     for data in usage.electricity:
-        print (data.interval.start, data.interval.end, data.cost, data.consumption)
-
+        print(data.interval.start, data.interval.end, data.cost, data.consumption)
     print(a.get_latest_point())
     print(a.get_latest_interval().start, a.get_latest_interval().end)
     print(a.get_latest_usage())

--- a/test.py
+++ b/test.py
@@ -7,8 +7,7 @@ async def main():
     a = BCHydroApi(os.environ.get("BCH_USER"), os.environ.get("BCH_PASS"))
     await a.authenticate()
     usage = await a.get_usage(hourly=False)
-    for data in usage.electricity:
-        print(data.interval.start, data.interval.end, data.cost, data.consumption)
+    print(usage.electricity)
     print(a.get_latest_point())
     print(a.get_latest_interval().start, a.get_latest_interval().end)
     print(a.get_latest_usage())


### PR DESCRIPTION
I was experiencing auth errors when I tried running test.py, I was encountering html login pages when it expected json. I tracked this down to a cookie issue - it seems you need to directly load the Accounts Overview page targetting a specific account/address, like https://app.bchydro.com/BCHCustomerPortal/web/accountsOverview.html?aid=B2Exxxxxxxxxxx - I recently moved, so my BCHydro profile contains an older "closed" address, so upon logging in I'm redirected to a "pick an account" accountsOverview.html , which doesn't seem to set the right cookies/session-state for URL_GET_ACCOUNT_JSON to work. 

This fix checks if we were redirected to the "select an account" page after initial login, and if so, fetches the list of (open) accounts, and loads the Account Overview page for that specific accountId, which allows the rest of the library to auth and work.

Also I saw your comment about Granularity: hourly, and snuck that in too :)

... I still can't seem to get HA to auth, using your `feat/updatecoordinator` branch, and using my local updated version of this library, but this is my first foray into custom HA components so I'm probably missing something obvious (unless your branch doesn't work?).