### PR TITLE
Restore hourly flag, resolve retry race conditions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,27 @@
+name: Pull Request
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install reqs
+      run: pip install -r requirements.txt
+    - name: Run test.py 
+      run: python test.py
+      env:
+        BCH_USER: ${{ secrets.bch_user }}
+        BCH_PASS: ${{ secrets.bch_pass }}
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable

--- a/bchydro/api.py
+++ b/bchydro/api.py
@@ -91,7 +91,7 @@ class BCHydroApi:
 
     def _detect_alert_errors(self, soup: BeautifulSoup):
         try:
-            alert_errors = soup.select('.alert.error:not(.hidden)')
+            alert_errors = soup.select(".alert.error:not(.hidden)")
         except TypeError:
             raise BCHydroInvalidHtmlException()
 
@@ -123,7 +123,6 @@ class BCHydroApi:
                 _LOGGER.debug(debug_msg)
 
             await self.refresh(hourly=hourly)
-
 
     @limits(calls=3, period=FIVE_MINUTES)
     async def _authenticate(self) -> bool:
@@ -189,7 +188,11 @@ class BCHydroApi:
 
         return True
 
-    @retry(stop=stop_after_attempt(2), wait=wait_fixed(1), retry=retry_if_exception_type(TryAgain))
+    @retry(
+        stop=stop_after_attempt(2),
+        wait=wait_fixed(1),
+        retry=retry_if_exception_type(TryAgain),
+    )
     async def refresh(self, hourly=False) -> BCHydroDailyUsage:
         if not self._is_cache_expired():
             _LOGGER.debug("Returning cached usage")

--- a/test.py
+++ b/test.py
@@ -5,12 +5,13 @@ from bchydro import BCHydroApi
 
 async def main():
     a = BCHydroApi(os.environ.get("BCH_USER"), os.environ.get("BCH_PASS"), cache_ttl=10)
-    # usage = await a.get_usage(hourly=False)
-    print(await a.get_usage())
-    print(await a.get_latest_point())
-    print(await a.get_latest_interval())
-    print(await a.get_latest_usage())
-    print(await a.get_latest_cost())
+    usage = await a.get_usage(hourly=False)
+    print(usage)
+
+    print("Latest point:", await a.get_latest_point())
+    print("Latest interval:", await a.get_latest_interval())
+    print("Latest usage:", await a.get_latest_usage())
+    print("Latest cost:", await a.get_latest_cost())
 
 
 asyncio.run(main())


### PR DESCRIPTION
Fixes the `get_usage(hourly=True)` functionality. 

It has become very clear that there will be a need for a more flexible request/query ORM in the future. As it stands now, the `hourly` flag is passed to `refresh()` which fetches hourly data and applies to all of the accessor methods and properties. It probably makes more sense if the data returned from the accessors doesn't depend on the last `refresh()` and whatever `hourly` state it used.

Resolves https://github.com/emcniece/bchydro/issues/7